### PR TITLE
added limits that will prevent climb motors from going too high

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -130,6 +130,7 @@ public final class Constants {
   public static final class ClimbConstants{
     public static final int kArmLeft = 40;
     public static final int kArmRight = 41;
+    public static final int heightLimit = 50; //NOT CLARIFIED AS THE LIMIT NUMBER, WILL NEED TO BE CHANGED
   }
   
   public static final class FulcrumConstants{

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -130,7 +130,8 @@ public final class Constants {
   public static final class ClimbConstants{
     public static final int kArmLeft = 40;
     public static final int kArmRight = 41;
-    public static final int heightLimit = 50; //NOT CLARIFIED AS THE LIMIT NUMBER, WILL NEED TO BE CHANGED
+    public static final int heightUpperLimit = 50; //TODO NOT CLARIFIED AS THE LIMIT NUMBER, WILL NEED TO BE CHANGED
+    public static final int heightLowerLimit = 5; //TODO NOT CLARIFIED AS THE LIMIT NUMBER, WILL NEED TO BE CHANGED
   }
   
   public static final class FulcrumConstants{

--- a/src/main/java/frc/robot/subsystems/Climb.java
+++ b/src/main/java/frc/robot/subsystems/Climb.java
@@ -18,14 +18,11 @@ import frc.robot.Constants.ClimbConstants;
 
 public class Climb extends SubsystemBase {
 
-  CANSparkMax m_RightArm =
-      new CANSparkMax(ClimbConstants.kArmRight, MotorType.kBrushless);
-  CANSparkMax m_LeftArm =
-      new CANSparkMax(ClimbConstants.kArmLeft, MotorType.kBrushless);
+  CANSparkMax m_RightArm = new CANSparkMax(ClimbConstants.kArmRight, MotorType.kBrushless);
+  CANSparkMax m_LeftArm = new CANSparkMax(ClimbConstants.kArmLeft, MotorType.kBrushless);
 
   RelativeEncoder e_RightArm;
   RelativeEncoder e_LeftArm;
-
 
   private double kP = 0.05;
   private double kI = 0.0;
@@ -58,10 +55,8 @@ public class Climb extends SubsystemBase {
     m_RightArm.setInverted(true);
     m_LeftArm.setInverted(false);
 
-
     e_RightArm = m_RightArm.getEncoder();
     e_LeftArm = m_LeftArm.getEncoder();
-
 
     m_constraints = new TrapezoidProfile.Constraints(maxVel, maxAcc);
     m_controller = new ProfiledPIDController(kP, kI, kD, m_constraints, kDt);
@@ -96,7 +91,7 @@ public class Climb extends SubsystemBase {
     return (Math.abs(error) < allowableError);
   }
 
-   public boolean isAtHeightLeft() {
+  public boolean isAtHeightLeft() {
     double error = getLeftHeight() - heightSetpoint;
     return (Math.abs(error) < allowableError);
   }
@@ -105,21 +100,25 @@ public class Climb extends SubsystemBase {
     return heightSetpoint;
   }
 
-  public void setHeightSetpoint(double setPoint) { 
+  public void setHeightSetpoint(double setPoint) {
     heightSetpoint = setPoint;
   }
 
   public void manualRightArm(double move) {
-    if (move > ClimbConstants.heightLimit)
-    m_RightArm.set(move);
+    if ((getRightHeight() < ClimbConstants.heightUpperLimit || move < 0) &&
+        (getRightHeight() > ClimbConstants.heightLowerLimit || move > 0)) {
+      m_RightArm.set(move);
+    }
   }
 
   public void manualLeftArm(double move) {
-    if (move > ClimbConstants.heightLimit)
-    m_LeftArm.set(move);
+    if ((getLeftHeight() < ClimbConstants.heightUpperLimit || move < 0) &&
+        (getLeftHeight() > ClimbConstants.heightLowerLimit || move > 0)) {
+      m_LeftArm.set(move);
+    }
   }
 
-  public void manualAll(double lift, double adjust){
+  public void manualAll(double lift, double adjust) {
     manualRightArm(lift + adjust);
     manualLeftArm(lift - adjust);
   }
@@ -138,7 +137,7 @@ public class Climb extends SubsystemBase {
     m_LeftArm.set(0.0);
   }
 
-  public void stopAll(){
+  public void stopAll() {
     stopRightArm();
     stopLeftArm();
   }

--- a/src/main/java/frc/robot/subsystems/Climb.java
+++ b/src/main/java/frc/robot/subsystems/Climb.java
@@ -105,15 +105,17 @@ public class Climb extends SubsystemBase {
     return heightSetpoint;
   }
 
-  public void setHeightSetpoint(double setPoint) {
+  public void setHeightSetpoint(double setPoint) { 
     heightSetpoint = setPoint;
   }
 
   public void manualRightArm(double move) {
+    if (move > ClimbConstants.heightLimit)
     m_RightArm.set(move);
   }
 
   public void manualLeftArm(double move) {
+    if (move > ClimbConstants.heightLimit)
     m_LeftArm.set(move);
   }
 


### PR DESCRIPTION
Added a new constant that is the height limit which is currently set to 50 since we do not know what to set it to, will change letter. Used in if statement in manual left and right methods to prevent move being too high.