### PR TITLE
changed resting set point for fulcrum

### DIFF
--- a/src/main/java/frc/robot/commands/FulcrumCmd.java
+++ b/src/main/java/frc/robot/commands/FulcrumCmd.java
@@ -31,7 +31,7 @@ public class FulcrumCmd extends Command {
                 this.fulcrum.setSetPoint(54.1);
                 break;
             case INTAKE:
-                this.fulcrum.setSetPoint(9);
+                this.fulcrum.setSetPoint(11);
                 break;
             case AMP:
                 this.fulcrum.setSetPoint(90);


### PR DESCRIPTION
As per chad, this branch just changes the the resting set point for the fulcrum at 11 instead of 9, to account for new attachments.