### PR TITLE
State

### DIFF
--- a/src/main/deploy/pathplanner/autos/Mammal Egg.auto
+++ b/src/main/deploy/pathplanner/autos/Mammal Egg.auto
@@ -105,9 +105,22 @@
           }
         },
         {
-          "type": "named",
+          "type": "parallel",
           "data": {
-            "name": "AutoShoot"
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "MidNote-MidSpeaker-Slow"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "AutoShoot"
+                }
+              }
+            ]
           }
         },
         {

--- a/src/main/deploy/pathplanner/autos/Squid.auto
+++ b/src/main/deploy/pathplanner/autos/Squid.auto
@@ -12,25 +12,6 @@
     "data": {
       "commands": [
         {
-          "type": "parallel",
-          "data": {
-            "commands": [
-              {
-                "type": "named",
-                "data": {
-                  "name": "AutoAim"
-                }
-              },
-              {
-                "type": "named",
-                "data": {
-                  "name": "AutoFulcrum"
-                }
-              }
-            ]
-          }
-        },
-        {
           "type": "named",
           "data": {
             "name": "ShootCmd"
@@ -62,28 +43,15 @@
           }
         },
         {
-          "type": "parallel",
+          "type": "named",
           "data": {
-            "commands": [
-              {
-                "type": "named",
-                "data": {
-                  "name": "AutoAim"
-                }
-              },
-              {
-                "type": "named",
-                "data": {
-                  "name": "AutoFulcrum"
-                }
-              }
-            ]
+            "name": "AutoAim"
           }
         },
         {
           "type": "named",
           "data": {
-            "name": "ShootCmd"
+            "name": "AutoShoot"
           }
         },
         {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -216,6 +216,12 @@ public class RobotContainer {
     operatorController.pov(90).onTrue(new FulcrumCmd(Position.SPEAKER, fulcrum, false));
     operatorController.pov(180).onTrue(new FulcrumCmd(Position.INTAKE, fulcrum, false));
 
+    operatorController.rightTrigger().onTrue(new RunCommand(() -> launcher.lancherBloop(), launcher));
+    operatorController.x().onTrue(new InstantCommand(() -> leds.setRobotStatus(RobotStatus.ROBOT_CENTRIC), leds));
+    
+
+
+
     // new JoystickButton(operatorController, GamePadButtons.Start)
     // .whileTrue(new InstantCommand(driveTrain::resetAll, driveTrain));
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -216,7 +216,7 @@ public class RobotContainer {
     operatorController.pov(90).onTrue(new FulcrumCmd(Position.SPEAKER, fulcrum, false));
     operatorController.pov(180).onTrue(new FulcrumCmd(Position.INTAKE, fulcrum, false));
 
-    operatorController.rightTrigger().whileTrue(new RunCommand(() -> launcher.lancherBloop(m_robotDrive.getVelocity()), launcher));
+    operatorController.rightTrigger().onTrue(new RunCommand(() -> launcher.lancherBloop(m_robotDrive.getVelocity()), launcher));
     operatorController.x().onTrue(new InstantCommand(() -> leds.setRobotStatus(RobotStatus.ROBOT_CENTRIC), leds));
     
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -176,6 +176,10 @@ public class RobotContainer {
     m_driverController.povUp().onTrue(new InstantCommand(() -> fulcrum.trimUp(), fulcrum));
     m_driverController.povDown().onTrue(new InstantCommand(() -> fulcrum.trimDown(), fulcrum));
     m_driverController.povLeft().onTrue(new InstantCommand(() -> fulcrum.resetTrim(), fulcrum));
+    m_driverController.y().whileTrue(new RunCommand(()-> m_robotDrive.AutoAimTriangle(
+        -MathUtil.applyDeadband(m_driverController.getLeftY(), OIConstants.kDriveDeadband)* DriveConstants.kMaxSpeedMetersPerSecond, 
+        -MathUtil.applyDeadband(m_driverController.getLeftX(), OIConstants.kDriveDeadband)* DriveConstants.kMaxSpeedMetersPerSecond), 
+        m_robotDrive));
     // operatorController.a().whileTrue(new RunCommand(() -> intake.intake(),
     // intake))
     // .onFalse(new RunCommand(() -> intake.intakeStop(), intake));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -216,7 +216,7 @@ public class RobotContainer {
     operatorController.pov(90).onTrue(new FulcrumCmd(Position.SPEAKER, fulcrum, false));
     operatorController.pov(180).onTrue(new FulcrumCmd(Position.INTAKE, fulcrum, false));
 
-    operatorController.rightTrigger().onTrue(new RunCommand(() -> launcher.lancherBloop(), launcher));
+    operatorController.rightTrigger().whileTrue(new RunCommand(() -> launcher.lancherBloop(m_robotDrive.getVelocity()), launcher));
     operatorController.x().onTrue(new InstantCommand(() -> leds.setRobotStatus(RobotStatus.ROBOT_CENTRIC), leds));
     
 

--- a/src/main/java/frc/robot/commands/AutoShootAndFulcrum.java
+++ b/src/main/java/frc/robot/commands/AutoShootAndFulcrum.java
@@ -25,6 +25,7 @@ public class AutoShootAndFulcrum extends Command {
     @Override
     public void initialize() {
         this.fulcrum.resetController();
+        
         this.fulcrum.setSetPoint(this.fulcrum.getAutoFulcrumAngle());
         
         // this.noteWasDetected = false;

--- a/src/main/java/frc/robot/commands/DriveToNote.java
+++ b/src/main/java/frc/robot/commands/DriveToNote.java
@@ -58,9 +58,9 @@ public class DriveToNote  extends Command {
             double y_output;
             double x_output = tX*xkP;
             if (tX < 5.0) {
-                y_output = (tY+20.0)*ykP;
+                y_output = (tY+20.0)*ykP+.25;
             } else {
-                y_output = 0.0;
+                y_output = 0.0 + .25;
             }
             System.out.println("x output:"+x_output);
             System.out.println("y output:"+y_output);

--- a/src/main/java/frc/robot/commands/FulcrumCmd.java
+++ b/src/main/java/frc/robot/commands/FulcrumCmd.java
@@ -31,7 +31,7 @@ public class FulcrumCmd extends Command {
                 this.fulcrum.setSetPoint(54.1);
                 break;
             case INTAKE:
-                this.fulcrum.setSetPoint(13);
+                this.fulcrum.setSetPoint(13.5);
                 break;
             case AMP:
                 this.fulcrum.setSetPoint(90);

--- a/src/main/java/frc/robot/commands/FulcrumCmd.java
+++ b/src/main/java/frc/robot/commands/FulcrumCmd.java
@@ -31,7 +31,7 @@ public class FulcrumCmd extends Command {
                 this.fulcrum.setSetPoint(54.1);
                 break;
             case INTAKE:
-                this.fulcrum.setSetPoint(12);
+                this.fulcrum.setSetPoint(13);
                 break;
             case AMP:
                 this.fulcrum.setSetPoint(90);

--- a/src/main/java/frc/robot/subsystems/Climb.java
+++ b/src/main/java/frc/robot/subsystems/Climb.java
@@ -58,12 +58,12 @@ public class Climb extends SubsystemBase {
 
     m_RightArm.enableSoftLimit(SoftLimitDirection.kForward, true);
     m_RightArm.enableSoftLimit(SoftLimitDirection.kReverse, true);
-    m_RightArm.setSoftLimit(SoftLimitDirection.kForward, 311);
+    m_RightArm.setSoftLimit(SoftLimitDirection.kForward, 175);
     m_RightArm.setSoftLimit(SoftLimitDirection.kReverse, 0);
 
     m_LeftArm.enableSoftLimit(SoftLimitDirection.kForward, true);
     m_LeftArm.enableSoftLimit(SoftLimitDirection.kReverse, true);
-    m_LeftArm.setSoftLimit(SoftLimitDirection.kForward, 311);
+    m_LeftArm.setSoftLimit(SoftLimitDirection.kForward, 175);
     m_LeftArm.setSoftLimit(SoftLimitDirection.kReverse, 0);
 
     e_RightArm = m_RightArm.getEncoder();

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -455,6 +455,15 @@ public class DriveSubsystem extends SubsystemBase {
     return Math.IEEEremainder(desiredAngle, 2 * Math.PI);
   }
 
+  public double angleToTriangle(){//TODO: get right angles
+    if(isRed()){
+      return 0.0;
+    }
+    else{
+      return 180.0;
+    }
+  }
+
   // public double autoAngleToTarget() {
   // double Ry = m_poseEstimator.getEstimatedPosition().getY();
   // double Rx = m_poseEstimator.getEstimatedPosition().getX();
@@ -509,6 +518,10 @@ public class DriveSubsystem extends SubsystemBase {
 
   public double currAngle() {
     return m_poseEstimator.getEstimatedPosition().getRotation().getRadians();
+  }
+
+  public double getVelocity(){
+    return m_frontRight.getVelocity();
   }
 
   public void autoAim() {

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -191,6 +191,7 @@ public class DriveSubsystem extends SubsystemBase {
     // SmartDashboard.putNumber("FL Velocity", m_frontLeft.getVelocity());
     // SmartDashboard.putNumber("RR Velocity", m_rearRight.getVelocity());
     // SmartDashboard.putNumber("RL Velocity", m_rearLeft.getVelocity());
+    SmartDashboard.putNumber("Drive Train Velocity", getVelocity());
     SmartDashboard.putNumber("FR Drive Current", m_frontRight.getDriveCurrent());
     SmartDashboard.putNumber("FL Drive Current", m_frontLeft.getDriveCurrent());
     SmartDashboard.putNumber("RR Drive Current", m_rearRight.getDriveCurrent());
@@ -455,12 +456,73 @@ public class DriveSubsystem extends SubsystemBase {
     return Math.IEEEremainder(desiredAngle, 2 * Math.PI);
   }
 
-  public double angleToTriangle(){//TODO: get right angles
-    if(isRed()){
-      return 0.0;
+  public double angleToTriangle(){//TODO: might be broken, please test
+    double Ry = m_poseEstimator.getEstimatedPosition().getY();
+    double Rx = m_poseEstimator.getEstimatedPosition().getX();
+    double desiredAngle = 0;
+    double Ty = 6.5;
+    double Tx;
+    if (isRed()) {
+      // Ty = 2.65;
+      Tx = 13.8;
+    } else {
+      // Ty = 5.55;
+      Tx =  3.85;
     }
-    else{
-      return 180.0;
+    if (Ry > Ty) {
+      if (isRed()) {
+        // desiredAngle = (Math.atan((Ry - Ty)/(Tx - Rx)) * (isRed() ? -1.0 : 1.0)) +
+        // Math.PI;
+        // desiredAngle = Math.atan((Ry - Ty) / (Tx - Rx)) + Math.PI;
+        // desiredAngle = Math.atan((Ty - Ry) / (Tx - Rx)) - Math.PI;
+
+        desiredAngle = Math.atan((Ty - Ry) / (Tx - Rx));
+        // desiredAngle = Math.IEEEremainder(desiredAngle, 2*Math.PI);
+      } else {
+        desiredAngle = -Math.atan((Ty - Ry) / Rx);
+      }
+
+    } else {
+      if (isRed()) {
+        // desiredAngle = (-Math.atan((Ty-Ry)/(Tx - Rx)) * (isRed() ? -1.0 : 1.0)) +
+        // Math.PI;
+        // desiredAngle = -Math.atan((Ty - Ry) / (Tx - Rx)) + Math.PI;
+        // desiredAngle = -Math.atan((Ry - Ty) / (Tx - Rx)) - Math.PI;
+        desiredAngle = -Math.atan((Ry - Ty) / (Tx - Rx));
+
+        // desiredAngle = Math.IEEEremainder(desiredAngle, 2*Math.PI);
+      } else {
+        desiredAngle = Math.atan((Ry - Ty) / Rx);
+      }
+
+    }
+    return Math.IEEEremainder(desiredAngle, 2 * Math.PI);
+  }
+
+  public double errorToTriangle() {
+    double error = angleToTriangle() - currAngle();
+    Rotation2d r1 = new Rotation2d().fromRadians(angleToTriangle());
+    Rotation2d r2 = new Rotation2d().fromRadians(currAngle());
+    Rotation2d r3 = r1.minus(r2);
+    if (isRed()) {
+      return r3.rotateBy(new Rotation2d().fromDegrees(180)).getRadians();
+    } else {
+      return r3.getRadians();
+    }
+  }
+
+  public void AutoAimTriangle(Double x, Double y){
+    double error = errorToTriangle();
+    // double error = angleToTarget() - m_poseEstimator.getEstimatedPosition().getRotation().getRadians();
+    // error = error * (isRed() ? -1.0 : 1.0);
+    kF = Math.copySign(kF, error);
+    double outF = kF;
+    double outP = kP * error;
+    double outputTurn = outF + outP;
+    if (Math.abs(error) > kAllowedError) { // if error is greater than ~5.7 deg (0.1 rad)
+      drive(x, y, outputTurn, false, false);
+    } else {
+      drive(x, y, 0, false, false);
     }
   }
 
@@ -521,7 +583,10 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   public double getVelocity(){
-    return m_frontRight.getVelocity();
+    double velocity_x = getChassisSpeed().vxMetersPerSecond;
+    double velocity_y = getChassisSpeed().vyMetersPerSecond;
+    double velocity = Math.sqrt(velocity_x * velocity_x + velocity_y * velocity_y);
+    return velocity;
   }
 
   public void autoAim() {

--- a/src/main/java/frc/robot/subsystems/Fulcrum.java
+++ b/src/main/java/frc/robot/subsystems/Fulcrum.java
@@ -28,7 +28,8 @@ public class Fulcrum extends SubsystemBase {
     private final CANSparkMax m_FulcrumLeft;
 
     private double lastSetpoint = 0;
-    private double setPoint = 0;
+    private double trimZero = 2.0;
+    private double setPoint = trimZero;
     private double autoAimTrim = 0;
 
     public double kP, kI, kD, kIz, kFF, kDt, kMaxOutput, kMinOutput, maxRPM, allowableError;
@@ -238,7 +239,7 @@ public class Fulcrum extends SubsystemBase {
     }
 
     public void resetTrim() {
-        autoAimTrim = 0;
+        autoAimTrim = trimZero;
     }
 
     public void trimUp() {
@@ -247,6 +248,10 @@ public class Fulcrum extends SubsystemBase {
 
     public void trimDown() {
         autoAimTrim -= 0.5;
+    }
+
+    public void setTrim(double trimValue){
+        autoAimTrim = trimValue;
     }
 
 }

--- a/src/main/java/frc/robot/subsystems/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/Launcher.java
@@ -97,7 +97,6 @@ public class Launcher extends SubsystemBase {
     public void periodic() {
         SmartDashboard.putNumber("Shooter Current", m_LauncherTop.getOutputCurrent());
         SmartDashboard.putNumber("Launcer Top RPM", m_LauncherEncoder.getVelocity());
-        ;
         SmartDashboard.putNumber("Launcer Bottom RPM", m_lowerLauncherEncoder.getVelocity());
         SmartDashboard.putNumber("Launcher SetPoint", setPoint);
         SmartDashboard.putBoolean("Launcher Is At Vel", isAtVelocity());
@@ -134,9 +133,9 @@ public class Launcher extends SubsystemBase {
         closedLoopLaunch();
     }
 
-    public void lancherBloop() {
+    public void lancherBloop(double velocity) {
         lastSetpoint = setPoint;
-        setPoint = 6500*.75;
+        setPoint = 4875 - 341.33 * velocity;
         closedLoopLaunch();
     }
 

--- a/src/main/java/frc/robot/subsystems/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/Launcher.java
@@ -134,6 +134,12 @@ public class Launcher extends SubsystemBase {
         closedLoopLaunch();
     }
 
+    public void lancherBloop() {
+        lastSetpoint = setPoint;
+        setPoint = 6500*.75;
+        closedLoopLaunch();
+    }
+
     public void stopLauncher() {
         lastSetpoint = setPoint;
         setPoint = 0;

--- a/src/main/java/frc/robot/subsystems/Leds.java
+++ b/src/main/java/frc/robot/subsystems/Leds.java
@@ -454,7 +454,7 @@ public void purpleStreak10() {
       case CLIMB: red(); break;
       case TARGET_LOCK: white(); break;
       case LAUNCH: blue(); break;
-      case NOTE_STORED: orange(); break;
+      case NOTE_STORED: orangePulse(); break;
       case INTAKE: if(RobotContainer.feeder.isNoteDetected()){orangeFlash();break;} greenPulse(); break;
       //case 1: purpleFlash(); break;
       //case 2: yellowFlash(); break;

--- a/src/main/java/frc/robot/subsystems/NoteLimeLight.java
+++ b/src/main/java/frc/robot/subsystems/NoteLimeLight.java
@@ -37,7 +37,7 @@ public class NoteLimeLight extends SubsystemBase {
         // System.out.println("tclass: "+tclass);
         // System.out.println("Is frisbee: "+(tclass.equals("frisbee")));
 
-        return (table.getEntry("tv").getDouble(0) == 1)&&(tclass.equals("frisbee")||tclass.equals("toilet"));
+        return (table.getEntry("tv").getDouble(0) == 1)&&(tclass.equals("frisbee")||tclass.equals("toilet")||tclass.equals("note"));
         // return (table.getEntry("tv").getDouble(0) == 1)&&((tclass == "toilet"||tclass == "frisbee"));
     }
 

--- a/src/main/java/frc/utils/RobotStatus.java
+++ b/src/main/java/frc/utils/RobotStatus.java
@@ -7,5 +7,6 @@ public enum RobotStatus{
     LAUNCH,
     ROBOT_CENTRIC,
     CLIMB,
-    TARGET_LOCK
+    TARGET_LOCK,
+    BLOOP
 }


### PR DESCRIPTION
This pull request reflects all the changes made since State. A brief summary is given below of the major changes:

Auto Methods:
Mammal Egg was changed to reflect the Copy of AIM_Mammal Egg on Roborio, this will allow us to make adjustments at worlds if need be
Squid was updated so that it did not miss its shots like it did at State

launcher:
A "bloop" method was added so that the drive team has less power when shooting for shuttling notes
bloop then went on to include velocity in reducing the speed of the motors to ensure notes don't fly out, even when moving
A new Aim method was added and mapped to the driver's Y button, this will aim the robot to the triangle of the field, made up of the podium, subwoofer, and Amp, as to more accurately shuttle notes.

Fulcrum:
the set point for the fulcrum was updated to reflect new hard stops

Climb:
new climb limits were created to reflect mechanical change.
